### PR TITLE
Change TODO handling

### DIFF
--- a/lib/Test2/API.pm
+++ b/lib/Test2/API.pm
@@ -272,9 +272,6 @@ sub run_subtest {
     $hub->listen(sub { push @events => $_[1] });
     $hub->format(undef) if $buffered;
 
-    my $no_diag = defined($parent->get_todo) || $parent->parent_todo;
-    $hub->set_parent_todo($no_diag) if $no_diag;
-
     my ($ok, $err, $finished);
     T2_SUBTEST_WRAPPER: {
         # Do not use 'try' cause it localizes __DIE__, and does not preserve $@
@@ -325,7 +322,6 @@ sub run_subtest {
     my $plan_ok = $state->check_plan;
 
     $e->set_diag([
-        $e->default_diag,
         $ok ? () : ("Caught exception in subtest: $err"),
         $plan_ok
             ? ()

--- a/lib/Test2/API/Context.pm
+++ b/lib/Test2/API/Context.pm
@@ -196,15 +196,12 @@ sub ok {
         trace => bless( {%{$self->{+TRACE}}}, 'Test2::Util::Trace'),
         pass  => $pass,
         name  => $name,
-        $hub->_fast_todo,
     }, 'Test2::Event::Ok';
     $e->init;
 
     return $hub->send($e) if $pass;
 
-    $diag ||= [];
-    unshift @$diag => $e->default_diag;
-    $e->set_diag($diag);
+    $e->set_diag($diag) if $diag;
 
     $hub->send($e);
 }
@@ -217,7 +214,6 @@ sub skip {
         name => $name,
         reason => $reason,
         pass => 1,
-        $self->hub->_fast_todo,
         @extra,
     );
 }
@@ -235,7 +231,6 @@ sub diag {
     $self->send_event(
         'Diag',
         message => $message,
-        todo => defined($hub->get_todo) || $hub->parent_todo,
     );
 }
 

--- a/lib/Test2/Event.pm
+++ b/lib/Test2/Event.pm
@@ -2,7 +2,7 @@ package Test2::Event;
 use strict;
 use warnings;
 
-use Test2::Util::HashBase qw/trace nested _meta/;
+use Test2::Util::HashBase qw/trace nested _meta todo diag_todo/;
 
 sub causes_fail  { 0 }
 
@@ -158,6 +158,23 @@ event then the default will be attached and returned.
 
     # Get the value, or set it to 'xxx' and get that.
     my $val = $e->get_meta('Foo::Bar', 'xxx');
+
+=item $todo = $e->todo
+
+=item $e->set_todo($todo)
+
+Get/Set the todo reason on the event. Any value other than C<undef> makes the
+event 'TODO'.
+
+Not all events make use of this field, but they can all have it set/cleared.
+
+=item $bool = $e->diag_todo
+
+=item $e->diag_todo($todo)
+
+True if this event should be considered 'TODO' for diagnostics purposes. This
+essentially means that any message that would go to STDERR will go to STDOUT
+instead so that a harness will hide it outside of verbose mode.
 
 =back
 

--- a/lib/Test2/Event/Diag.pm
+++ b/lib/Test2/Event/Diag.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 
 use base 'Test2::Event';
-use Test2::Util::HashBase qw{message todo};
+use Test2::Util::HashBase qw{message};
 
 sub init {
     $_[0]->{+MESSAGE} = 'undef' unless defined $_[0]->{+MESSAGE};

--- a/lib/Test2/Event/Ok.pm
+++ b/lib/Test2/Event/Ok.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Event';
 use Test2::Util::HashBase qw{
-    pass effective_pass name diag allow_bad_name todo diag_todo
+    pass effective_pass name diag allow_bad_name
 };
 
 sub init {
@@ -12,8 +12,7 @@ sub init {
 
     # Do not store objects here, only true or false
     $self->{+PASS} = $self->{+PASS} ? 1 : 0;
-
-    $self->{+EFFECTIVE_PASS} = ($self->{+PASS} || defined($self->{+TODO})) ? 1 : 0;
+    $self->{+EFFECTIVE_PASS} = $self->{+PASS} || (defined($self->{+TODO}) ? 1 : 0);
 
     return if $self->{+ALLOW_BAD_NAME};
     my $name = $self->{+NAME} || return;
@@ -21,29 +20,11 @@ sub init {
     $self->trace->throw("'$name' is not a valid name, names must not contain '#' or newlines.")
 }
 
-sub default_diag {
+sub set_todo {
     my $self = shift;
-
-    return if $self->{+PASS};
-
-    my $name  = $self->{+NAME};
-    my $trace = $self->{+TRACE};
-    my $pass  = $self->{+PASS};
-    my $todo  = defined($self->{+TODO});
-
-    my $msg = $todo ? "Failed (TODO)" : "Failed";
-    my $prefix = $ENV{HARNESS_ACTIVE} && !$ENV{HARNESS_IS_VERBOSE} ? "\n" : "";
-
-    my $debug = $trace ? $trace->debug : "[No trace info available]";
-
-    if (defined $name) {
-        $msg = qq[$prefix$msg test '$name'\n$debug.];
-    }
-    else {
-        $msg = qq[$prefix$msg test $debug.];
-    }
-
-    return $msg;
+    my ($todo) = @_;
+    $self->SUPER::set_todo($todo);
+    $self->{+EFFECTIVE_PASS} = defined($todo) ? 1 : $self->{+PASS};
 }
 
 sub update_state { $_[1]->bump($_[0]->{+EFFECTIVE_PASS}) }
@@ -106,32 +87,15 @@ Name of the test.
 
 An arrayref full of diagnostics strings to print in the event of a failure.
 
-B<Note:> This does not have anything by default, the C<default_diag()> method
-can be used to generate the basic diagnostics message which you may push into
-this arrayref.
-
 =item $b = $e->effective_pass
 
-This is the true/false value of the test after TODO, SKIP, and similar
-modifiers are taken into account.
+This is the true/false value of the test after TODO and similar modifiers are
+taken into account.
 
 =item $b = $e->allow_bad_name
 
 This relaxes the test name checks such that they allow characters that can
 confuse a TAP parser.
-
-=back
-
-=head1 METHODS
-
-=over 4
-
-=item $string = $e->default_diag()
-
-This generates the default diagnostics string:
-
-    # Failed test 'Some Test'
-    # at t/foo.t line 42.
 
 =back
 

--- a/lib/Test2/Event/Skip.pm
+++ b/lib/Test2/Event/Skip.pm
@@ -11,6 +11,13 @@ sub init {
     $self->{+EFFECTIVE_PASS} = 1;
 }
 
+sub set_todo {
+    my $self = shift;
+    my ($todo) = @_;
+    $self->SUPER::set_todo($todo);
+    $self->{+EFFECTIVE_PASS} = 1;
+}
+
 sub update_state { $_[1]->bump(1) }
 
 sub causes_fail { 0 }

--- a/lib/Test2/Formatter/TAP.pm
+++ b/lib/Test2/Formatter/TAP.pm
@@ -132,30 +132,65 @@ sub _ok_event {
     # We use direct hash access for performance. OK events are so common we
     # need this to be fast.
     my ($name, $todo) = @{$e}{qw/name todo/};
+    my $in_todo = defined($todo);
 
     my $out = "";
     $out .= "not " unless $e->{pass};
     $out .= "ok";
     $out .= " $num" if defined $num;
     $out .= " - $name" if defined $name;
+    $out .= " # TODO" if $in_todo;
+    $out .= " $todo" if length $todo;
 
-    if (defined $todo) {
-        $out .= " # TODO";
-        $out .= " $todo" if length $todo;
-    }
-
+    # The primary line of TAP, if the test passed this is all we need.
     my @out = [OUT_STD, "$out\n"];
+    return @out if $e->pass;
 
-    if ($e->{diag} && @{$e->{diag}}) {
-        my $diag_handle = ($todo || $e->diag_todo) ? OUT_TODO : OUT_ERR;
+    #################
+    # The rest of this is production of the diagnostics messages.
+    #################
 
-        for my $diag (@{$e->{diag}}) {
-            chomp(my $msg = $diag);
+    # Figure out if the message goes to STDERR or to the TODO handle (typically STDOUT)
+    # If the OK is either todo, or has the diag_todo set then this should go to
+    # the TODO handle.
+    my $diag_handle = (defined($todo) || $e->diag_todo) ? OUT_TODO : OUT_ERR;
 
-            $msg = "# $msg" unless $msg =~ m/^\n/;
-            $msg =~ s/\n/\n# /g;
-            push @out => [$diag_handle, "$msg\n"];
-        }
+    # This behavior is inherited from Test::Builder which injected a newline at
+    # the start of the first diagnostics when the harness is active, but not
+    # verbose. This is important to keep the diagnostics from showing up
+    # appended to the existing line, which is hard to read. In a verbose
+    # harness there is no need for this.
+    my $prefix = $ENV{HARNESS_ACTIVE} && !$ENV{HARNESS_IS_VERBOSE} ? "\n" : "";
+
+    # Figure out the debug info, this is typically the file name and line
+    # number, but can also be a custom message. If no trace object is provided
+    # then we have nothing useful to display.
+    my $trace  = $e->trace;
+    my $debug  = $trace ? $trace->debug : "[No trace info available]";
+
+    # Create the initial diagnostics. If the test has a name we put the debug
+    # info on a second line, this behavior is inherited from Test::Builder.
+    my $msg = $in_todo ? "Failed (TODO)" : "Failed";
+    $msg = defined($name)
+        ? qq[$prefix# $msg test '$name'\n# $debug.\n]
+        : qq[$prefix# $msg test $debug.\n];
+
+    # Add the initial diagnostics line to the output list.
+    push @out => [$diag_handle, $msg];
+
+    # Sometimes additional diagnostics messages are associated with the Ok
+    # object, we are going to display them as well.
+    for my $diag (@{$e->diag || []}) {
+        # Remove any trailing newlines, they are not consistently provided, and
+        # we will add our own at the end.
+        chomp(my $diag = $diag);
+
+        # Add the '#' prefix to all lines, but skip the leading newlines.
+        $diag = "# $diag" unless $diag =~ m/^\n/;
+        $diag =~ s/\n/\n# /g;
+
+        # Add the message to the output.
+        push @out => [$diag_handle, "$diag\n"];
     }
 
     return @out;
@@ -206,7 +241,7 @@ sub _diag_event {
     $msg =~ s/\n/\n# /g;
 
     return [
-        $e->todo ? OUT_TODO : OUT_ERR,
+        ($e->todo || $e->diag_todo) ? OUT_TODO : OUT_ERR,
         "$msg\n",
     ];
 }
@@ -233,30 +268,41 @@ sub _subtest_event {
     my $self = shift;
     my ($e, $num) = @_;
 
+    # A 'subtest' is a subclass of 'ok'. Let the code that renders 'ok' render
+    # this event.
     my ($ok, @diag) = $self->_ok_event($e, $num);
 
-    return (
-        $ok,
-        @diag
-    ) unless $e->buffered;
+    # If the subtest is not buffered then the sub-events have already been
+    # rendered, we can go ahead and return.
+    return ($ok, @diag) unless $e->buffered;
 
+    # In a verbose harness we indent the diagnostics from the 'Ok' event since
+    # they will appear inside the subtest braces. This helps readability. In a
+    # non-verbose harness we do nto do this because it is less readable.
     if ($ENV{HARNESS_IS_VERBOSE}) {
-        $_->[1] =~ s/^/    /mg for @diag;
+        # index 0 is the filehandle, index 1 is the message we want to indent.
+        $_->[1] =~ s/^(.*\S)$/    $1/mg for @diag;
     }
 
+    # Add the trailing ' {' to the 'ok' line of TAP output.
     $ok->[1] =~ s/\n/ {\n/;
 
+    # Render the sub-events, we use our own counter for these.
     my $count = 0;
     my @subs = map {
+        # Bump the count for any event that inherits from Ok.
         $count++ if $_->isa('Test2::Event::Ok');
-        map { $_->[1] =~ s/^/    /mg; $_ } $self->event_tap($_, $count);
+
+        # This indents all output lines generated for the sub-events.
+        # index 0 is the filehandle, index 1 is the message we want to indent.
+        map { $_->[1] =~ s/^(.*\S)$/    $1/mg; $_ } $self->event_tap($_, $count);
     } @{$e->subevents};
 
     return (
-        $ok,
-        @diag,
-        @subs,
-        [OUT_STD(), "}\n"],
+        $ok,                # opening ok - name {
+        @diag,              #   diagnostics if the subtest failed
+        @subs,              #   All the inner-event lines
+        [OUT_STD(), "}\n"], # } (closing brace)
     );
 }
 

--- a/lib/Test2/Hub.pm
+++ b/lib/Test2/Hub.pm
@@ -12,7 +12,7 @@ use Test2::Util::HashBase qw{
     pid tid hid ipc
     state
     no_ending
-    _todo _meta parent_todo
+    _meta
     _filters
     _listeners
     _follow_ups
@@ -29,7 +29,6 @@ sub init {
     $self->{+TID} = get_tid();
     $self->{+HID} = join '-', $self->{+PID}, $self->{+TID}, $ID_POSTFIX++;
 
-    $self->{+_TODO} = [];
     $self->{+_META} = {};
 
     $self->{+STATE} ||= Test2::Hub::State->new;
@@ -65,17 +64,6 @@ sub inherit {
     }
 }
 
-sub _fast_todo {
-    my ($self) = @_;
-    my $array = $self->{+_TODO};
-    pop @$array while @$array && !defined $array->[-1];
-    my $todo = @$array ? ${$array->[-1]} : undef;
-    return (
-        diag_todo => defined($todo) || $self->{+PARENT_TODO},
-        todo      => $todo,
-    )
-}
-
 sub meta {
     my $self = shift;
     my ($key, $default) = @_;
@@ -99,34 +87,6 @@ sub delete_meta {
         unless $key;
 
     delete $self->{+_META}->{$key};
-}
-
-sub set_todo {
-    my $self = shift;
-    my ($reason) = @_;
-
-    unless (defined wantarray) {
-        carp "set_todo(...) called in void context, todo not set!";
-        return;
-    }
-
-    unless(defined $reason) {
-        carp "set_todo() called with undefined argument, todo not set!";
-        return;
-    }
-
-    my $ref = \$reason;
-    push @{$self->{+_TODO}} => $ref;
-    weaken($self->{+_TODO}->[-1]);
-    return $ref;
-}
-
-sub get_todo {
-    my $self = shift;
-    my $array = $self->{+_TODO};
-    pop @$array while @$array && !defined($array->[-1]);
-    return undef unless @$array;
-    return ${$array->[-1]};
 }
 
 sub format {
@@ -496,62 +456,6 @@ This will delete all data in the specified metadata key.
 
 This method will retrieve the value of any meta-data key specified.
 
-=item $string = $hub->get_todo()
-
-Get the current TODO reason. This will be undef if there is no active todo.
-Please note that 0 and C<''> (empty string) count as active todo.
-
-=item $ref = $hub->set_todo($reason)
-
-This will set the todo message. The todo will remain in effect until you let go
-of the reference returned by this method.
-
-    {
-        my $todo = $hub->set_todo("Broken");
-
-        # These ok events will be TODO
-        ok($foo->doit, "do it!");
-        ok($foo->doit, "do it again!");
-
-        # The todo setting goes away at the end of this scope.
-    }
-
-    # This result will not be TODO.
-    ok(1, "pass");
-
-You can also do it without the indentation:
-
-    my $todo = $hub->set_todo("Broken");
-
-    # These ok events will be TODO
-    ok($foo->doit, "do it!");
-    ok($foo->doit, "do it again!");
-
-    # Unset the todo
-    $todo = undef;
-
-    # This result will not be TODO.
-    ok(1, "pass");
-
-This method can be called while TODO is already in effect and it will work in a
-sane way:
-
-    {
-        my $first_todo = $hub->set_todo("Will fix soon");
-
-        ok(0, "Not fixed"); # TODO: Will fix soon
-
-        {
-            my $second_todo = $hub->set_todo("Will fix eventually");
-            ok(0, "Not fixed"); # TODO: Will fix eventually
-        }
-
-        ok(0, "Not fixed"); # TODO: Will fix soon
-    }
-
-This also works if you free todo's out of order. The most recently set todo
-that is still active will always be used as the todo.
-
 =item $old = $hub->format($formatter)
 
 Replace the existing formatter instance with a new one. Formatters must be
@@ -652,10 +556,6 @@ Get the IPC object used by the hub.
 This can be used to disable auto-ending behavior for a hub. The auto-ending
 behavior is triggered by an end block and is used to cull IPC events, and
 output the final plan if the plan was 'no_plan'.
-
-=item $bool = $hub->parent_todo
-
-This will be true if this hub is a child hub who's parent had todo set.
 
 =back
 

--- a/t/acceptance/try_it_todo.t
+++ b/t/acceptance/try_it_todo.t
@@ -21,12 +21,17 @@ sub ok($;$) {
 
 ok(1, "First");
 
-my $todo = test2_stack()->top->set_todo('here be dragons');
+my $filter = test2_stack->top->filter(sub {
+    my ($hub, $event) = @_;
+    $event->set_todo('here be dragons');
+    $event->diag_todo(1);
+    return $event;
+});
+
 ok(0, "Second");
-$todo = undef;
+
+test2_stack->top->unfilter($filter);
 
 ok(1, "Third");
 
 done_testing;
-
-1;

--- a/t/modules/API/Context.t
+++ b/t/modules/API/Context.t
@@ -121,18 +121,6 @@ is(@$events, 1, "1 event");
 is_deeply($events, [$e], "Hub saw the event");
 pop @$events;
 
-$ctx->hub->set_parent_todo(1);
-$e = $ctx->diag('foo');
-$ctx->hub->set_parent_todo(0);
-ok($e->todo, "diag is todo");
-pop @$events;
-
-my $todo = $ctx->hub->set_todo("xxx");
-$e = $ctx->diag('foo');
-$todo = undef; # end todo
-ok($e->todo, "diag is todo");
-pop @$events;
-
 $e = $ctx->plan(100);
 is($e->max, 100, "got max");
 is_deeply($e->trace, $trace, "Got the trace info");
@@ -147,12 +135,6 @@ ok($e->pass, "skip events pass by default");
 is_deeply($e->trace, $trace, "Got the trace info");
 is(@$events, 1, "1 event");
 is_deeply($events, [$e], "Hub saw the event");
-pop @$events;
-
-$todo = $ctx->hub->set_todo("xxx");
-$e = $ctx->skip('foo', 'because');
-$todo = undef;
-ok($e->todo, "event is todo");
 pop @$events;
 
 $e = $ctx->skip('foo', 'because', pass => 0);
@@ -363,11 +345,9 @@ sub {
         $ctx->release;
     };
 
-    like($e1->diag->[0], qr/Failed test 'foo'/, "event 1 diag 1");
-    is($e1->diag->[1], 'xxx', "event 1 diag 2");
+    is($e1->diag->[0], 'xxx', "event 1 diag 2");
 
-    like($e2->diag->[0], qr/Failed test 'foo'/, "event 1 diag 1");
-    is(@{$e2->diag}, 1, "only 1 diag for event 2");
+    ok(!$e2->diag, "no diag for event 2");
 }
 
 done_testing;

--- a/t/modules/Event/Ok.t
+++ b/t/modules/Event/Ok.t
@@ -48,11 +48,7 @@ tests Failing => sub {
     is($ok->name, 'the_test', "got name");
     is($ok->effective_pass, 0, "effective pass");
 
-    is(
-        $ok->default_diag,
-        "Failed test 'the_test'\nat foo.t line 42.",
-        "default diag"
-    );
+    ok(!$ok->diag, "no default diag");
 
     my $state = Test2::Hub::State->new;
     $ok->update_state($state);
@@ -68,8 +64,8 @@ tests fail_with_diag => sub {
         trace => $trace,
         pass  => 0,
         name  => 'the_test',
-        diag  => ['xxx'],
     );
+    $ok->set_diag(['xxx']),
     is($ok->pass, 0, "got pass");
     is($ok->name, 'the_test', "got name");
     is($ok->effective_pass, 0, "effective pass");
@@ -100,12 +96,7 @@ tests "Failing TODO" => sub {
     is($ok->name, 'the_test', "got name");
     is($ok->effective_pass, 1, "effective pass is true from todo");
 
-    $ok->set_diag([ $ok->default_diag ]);
-    is_deeply(
-        $ok->diag,
-        [ "Failed (TODO) test 'the_test'\nat foo.t line 42." ],
-        "Got diag"
-    );
+    ok(!$ok->diag, "no default diag");
 
     my $state = Test2::Hub::State->new;
     $ok->update_state($state);
@@ -148,17 +139,6 @@ tests init => sub {
         allow_bad_name => 1,
     );
     ok($ok, "allowed the bad name");
-};
-
-tests default_diag => sub {
-    my $ok = Test2::Event::Ok->new(trace => $trace, pass => 1);
-    is_deeply([$ok->default_diag], [], "no diag for a pass");
-
-    $ok = Test2::Event::Ok->new(trace => $trace, pass => 0);
-    like($ok->default_diag, qr/Failed test at foo\.t line 42/, "got diag w/o name");
-
-    $ok = Test2::Event::Ok->new(trace => $trace, pass => 0, name => 'foo');
-    like($ok->default_diag, qr/Failed test 'foo'\nat foo\.t line 42/, "got diag w/name");
 };
 
 done_testing;

--- a/t/modules/Formatter/TAP.t
+++ b/t/modules/Formatter/TAP.t
@@ -225,6 +225,7 @@ tests note => sub {
 };
 
 for my $pass (1, 0) {
+    local $ENV{HARNESS_IS_VERBOSE} = 1;
     tests name_and_number => sub {
         my $ok = Test2::Event::Ok->new(trace => $trace, pass => $pass, name => 'foo');
         my @tap = $fmt->event_tap($ok, 7);
@@ -232,6 +233,7 @@ for my $pass (1, 0) {
             \@tap,
             [
                 [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7 - foo\n"],
+                $pass ? () : [OUT_ERR, "# Failed test 'foo'\n# at foo.t line 42.\n"],
             ],
             "Got expected output"
         );
@@ -244,6 +246,7 @@ for my $pass (1, 0) {
             \@tap,
             [
                 [OUT_STD, ($pass ? 'ok' : 'not ok') . " - foo\n"],
+                $pass ? () : [OUT_ERR, "# Failed test 'foo'\n# at foo.t line 42.\n"],
             ],
             "Got expected output"
         );
@@ -256,6 +259,7 @@ for my $pass (1, 0) {
             \@tap,
             [
                 [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7\n"],
+                $pass ? () : [OUT_ERR, "# Failed test at foo.t line 42.\n"],
             ],
             "Got expected output"
         );
@@ -269,6 +273,7 @@ for my $pass (1, 0) {
             \@tap,
             [
                 [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7 # TODO b\n"],
+                $pass ? () : [OUT_TODO, "# Failed (TODO) test at foo.t line 42.\n"],
             ],
             "Got expected output"
         );
@@ -280,6 +285,7 @@ for my $pass (1, 0) {
             \@tap,
             [
                 [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7 # TODO\n"],
+                $pass ? () : [OUT_TODO, "# Failed (TODO) test at foo.t line 42.\n"],
             ],
             "Got expected output"
         );
@@ -292,8 +298,9 @@ for my $pass (1, 0) {
             \@tap,
             [
                 [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7\n"],
+                $pass ? () : [OUT_ERR, "# Failed test at foo.t line 42.\n"],
             ],
-            "Got expected output (No diag)"
+            "Got expected output (No added diag)"
         );
 
         $ok = Test2::Event::Ok->new(trace => $trace, pass => $pass);
@@ -302,8 +309,9 @@ for my $pass (1, 0) {
             \@tap,
             [
                 [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7\n"],
+                $pass ? () : [OUT_ERR, "# Failed test at foo.t line 42.\n"],
             ],
-            "Got expected output (No diag)"
+            "Got expected output (No added diag)"
         );
     };
 
@@ -319,6 +327,7 @@ for my $pass (1, 0) {
             [$fmt->event_tap($ok, 4)],
             [
                 [OUT_STD, "not ok 4 - the_test\n"],
+                [OUT_ERR, "# Failed test 'the_test'\n# at foo.t line 42.\n"],
                 [OUT_ERR, "# xxx\n"],
             ],
             "Got tap for failing ok"
@@ -435,9 +444,11 @@ tests subtest => sub {
             [$fmt->event_tap($one, 5)],
             [
                 [OUT_STD, "not ok 5 - bar {\n"],
+                [OUT_ERR, "\n# Failed test 'bar'\n# at foo.t line 42.\n"],
                 [OUT_ERR, "# bar failed\n"],
                 [OUT_STD, "    ok 1 - first\n"],
                 [OUT_STD, "    not ok 2 - second\n"],
+                [OUT_ERR, "\n    # Failed test 'second'\n    # at foo.t line 42.\n"],
                 [OUT_ERR, "    # second failed\n"],
                 [OUT_STD, "    ok 3 - third\n"],
                 [OUT_ERR, "    # blah blah\n"],
@@ -454,9 +465,11 @@ tests subtest => sub {
             [$fmt->event_tap($one, 5)],
             [
                 [OUT_STD, "not ok 5 - bar {\n"],
+                [OUT_ERR, "    # Failed test 'bar'\n    # at foo.t line 42.\n"],
                 [OUT_ERR, "    # bar failed\n"],
                 [OUT_STD, "    ok 1 - first\n"],
                 [OUT_STD, "    not ok 2 - second\n"],
+                [OUT_ERR, "    # Failed test 'second'\n    # at foo.t line 42.\n"],
                 [OUT_ERR, "    # second failed\n"],
                 [OUT_STD, "    ok 3 - third\n"],
                 [OUT_ERR, "    # blah blah\n"],
@@ -475,6 +488,7 @@ tests subtest => sub {
             [
                 # In unbuffered TAP the subevents are rendered outside of this.
                 [OUT_STD, "not ok 5 - bar\n"],
+                [OUT_ERR, "\n# Failed test 'bar'\n# at foo.t line 42.\n"],
                 [OUT_ERR, "# bar failed\n"],
             ],
             "Got Unbuffered TAP output (non-verbose)"
@@ -489,6 +503,7 @@ tests subtest => sub {
             [
                 # In unbuffered TAP the subevents are rendered outside of this.
                 [OUT_STD, "not ok 5 - bar\n"],
+                [OUT_ERR, "# Failed test 'bar'\n# at foo.t line 42.\n"],
                 [OUT_ERR, "# bar failed\n"],
             ],
             "Got Unbuffered TAP output (verbose)"

--- a/t/modules/Hub.t
+++ b/t/modules/Hub.t
@@ -325,45 +325,4 @@ tests filter => sub {
     );
 };
 
-tests todo_system => sub {
-    my $hub = Test2::Hub->new();
-
-    {
-        my $todo = $hub->set_todo('foo');
-        ok($todo, "True");
-        is($hub->get_todo, 'foo', "In todo");
-    }
-
-    is($hub->get_todo, undef, "Todo ended");
-
-    my $todo = $hub->set_todo('foo');
-    ok($todo, "True");
-    is($hub->get_todo, 'foo', "In todo");
-    $todo = undef;
-    is($hub->get_todo, undef, "Todo ended");
-
-    # Imitate Test::Builders todo:
-    our $TODOX;
-    {
-        local $TODOX = $hub->set_todo('foo');
-        ok($TODOX, "True");
-        is($hub->get_todo, 'foo', "In todo");
-    }
-    is($hub->get_todo, undef, "Todo ended");
-
-    my $warnings = warnings { $hub->set_todo('xxx') };
-    like(
-        $warnings->[0],
-        qr/set_todo\Q(...)\E called in void context, todo not set!/,
-        "Need to capture the todo!"
-    );
-
-    $warnings = warnings { my $todo = $hub->set_todo() },
-    like(
-        $warnings->[0],
-        qr/set_todo\(\) called with undefined argument, todo not set!/,
-        "Todo cannot be undef"
-    );
-};
-
 done_testing;


### PR DESCRIPTION
This makes it so that hubs no longer have special logic for TODO states.
This greatly simplifies the hubs.

TODO can be added to events using filters. Test::Builder will be doing
this. This also makes it possible for people to make their own todo
modules if they want. There will be a basic todo tool included with the
new tools in a seperate dist.

The event base class now has the 'todo', and 'diag_todo' fields, which
should be universally available in events. When a todo filter is in
place it will modify these fields on all events that come through.

This has the potential benefit of being faster, not sure though, have
not benchmarked, it is not a motivating factor.

This also requires the 'default diag' logic to be moved out of OK and
into the TAP formatter. I think it is better there anyway, the default
diagnostics are very much tied to TAP anyway. It is reasonable for other
formatters to omit the default diagnostics, or create their own .
